### PR TITLE
Add capability to bundle modules which cannot be downloaded via the pom.xml file 

### DIFF
--- a/modules/contents.txt
+++ b/modules/contents.txt
@@ -1,0 +1,3 @@
+Copy any .omod files here which cannot be downloaded via the pom.xml file
+
+This file is ignored by the task the copies the resources to the modules folder in the WAR file

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,30 @@
                             </resources>
                         </configuration>
                     </execution>
+                    <!-- Copy the omods in the modules directory which are not downloadable from http://mavenrepo.openmrs.org/nexus -->
+                    <execution>
+                        <id>copy-downloaded-modules</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/${modulesFolder}</outputDirectory>
+                            <!-- prevent corruption of binary files by filtering activity which may be needed -->
+                            <nonFilteredFileExtensions>
+                                <nonFilteredFileExtension>omod</nonFilteredFileExtension>
+                            </nonFilteredFileExtensions>
+                            <resources>
+                                <resource>
+                                    <directory>modules</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>*.omod</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>


### PR DESCRIPTION
Added a modules directory to which third party modules that cannot be downloaded from the Nexus repository or another 3rd party repository via the pom.xml can be placed for bundling into a war file\

Added a copy resources task to the pom.xml to copy any .omod files in the modules directory

PS: I have not used an issue branch since this project is not included in Jira