### PR TITLE
Add openmrs maven repositories, avoiding downloading things from maven central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,5 +158,22 @@
             </plugin>
         </plugins>
     </build>
+    <repositories>
+  		<repository>
+  			<id>openmrs-repo</id>
+  			<name>OpenMRS Nexus Repository</name>
+  			<url>http://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
+  		</repository>
+  	</repositories>
 
+  	<pluginRepositories>
+  		<pluginRepository>
+  			<id>openmrs-repo</id>
+  			<name>OpenMRS Nexus Repository</name>
+  			<url>http://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
+  			<snapshots>
+  				<enabled>false</enabled>
+  			</snapshots>
+  		</pluginRepository>
+  </pluginRepositories>
 </project>


### PR DESCRIPTION
Without this, artefacts are downloaded from maven central unless you have a global configuration. 