### PR TITLE
[PLAT-30] Bundle the Add-On manager OWA within the Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,21 @@ Before you do anything else, you need to verify what modules should be bundled w
  * webservices.rest
  * owa
  * fhir
- 
+
 If any of these modules have significant recent commits that have not been released yet, then consider releasing them before you do the platform release.
+
+### What OWAs to include?
+
+The platform also comes bundled with some Open Web Applications (OWAs). Verify that the following OWAs are bundled with this version of the OpenMRS Platform. At the time of writing, these include:
+
+* Add On Manager 
 
 ###Building the project
  * Clone the project onto your machine if you haven't yet.
  * Check out the branch corresponding to the release line you want to release (e.g. the 2.0.x branch for Platform 2.0.4)
  * Update the **version** property value in the pom file to match the version of OpenMRS platform you're building
  * In the **properties** section of pom.xml update all module version properties (e.g. *webservices.restVersion*) to match the versions you wish to bundle
- * Ensure that the openmrs-distro.properties file includes all bundled modules (e.g. *omod.webservices.rest*)
+ * Ensure that the openmrs-distro.properties file includes all bundled modules (e.g. *omod.webservices.rest*) as well as all bundled OWAs (e.g. *owa.openmrs-owa-addonmanager*)
  * Build the distributable by running the command below: 
  
   ``` 

--- a/openmrs-distro.properties
+++ b/openmrs-distro.properties
@@ -4,5 +4,6 @@ war.openmrs=${openmrsPlatformVersion}
 omod.webservices.rest=${webservices.restVersion}
 omod.owa=${owaVersion}
 omod.fhir=${fhirVersion}
+owa.openmrs-owa-addonmanager=${addonManagerVersion}
 #db.h2.supported=true
 #db.sql=classpath://openmrs-distro.sql

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
 		<webservices.restVersion>2.21.0</webservices.restVersion>
 		<owaVersion>1.9.0</owaVersion>
 		<fhirVersion>1.11.0</fhirVersion>
+		<addonManagerVersion>1.0.0-beta2</addonManagerVersion>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
## JIRA TICKET NAME:
[[PLAT-30] Bundle the Add-On manager OWA within the Platform](https://issues.openmrs.org/browse/PLAT-30)
### SUMMARY:
We want to include the Add-On manager with the Platform. This may involve more than simply including the OWA – i.e., we may need to edit or add a landing page for the Platform in order for the Add-On manager to be reachable out of the box

This PR solves most of the issue description. The second half of the issue is addressed [here](https://github.com/openmrs/openmrs-core/pull/2568)