### PR TITLE
Updating the version of the REST Module to 2.38.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<openmrsPlatformVersion>${project.version}</openmrsPlatformVersion>
-		<webservices.restVersion>2.36.0</webservices.restVersion>
+		<webservices.restVersion>2.38.0</webservices.restVersion>
 		<owaVersion>1.14.0</owaVersion>
 		<fhirVersion>1.8.0</fhirVersion>
 		<addonManagerVersion>1.1.0</addonManagerVersion>


### PR DESCRIPTION
This is intended to update the version of the [rest module](https://github.com/openmrs/openmrs-module-webservices.rest) to the latest version which is **2.38.0**

/cc: @dkayiwa @ibacher 