### PR TITLE
Bump fhir and webservices module versions for 2.8.0 release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,9 +37,9 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<openmrsPlatformVersion>${project.version}</openmrsPlatformVersion>
-		<webservices.restVersion>2.49.0</webservices.restVersion>
+		<webservices.restVersion>2.50.0</webservices.restVersion>
 		<owaVersion>1.15.0</owaVersion>
-		<fhirVersion>2.6.0</fhirVersion>
+		<fhirVersion>2.7.0</fhirVersion>
 		<addonManagerVersion>1.1.0</addonManagerVersion>
 	</properties>
 


### PR DESCRIPTION
Bump fhir and webservices module versions for 2.8.0 platform release.